### PR TITLE
fixed the name of one of the figures in the input file documentation

### DIFF
--- a/docs/source/user/beamdyn/input_files.rst
+++ b/docs/source/user/beamdyn/input_files.rst
@@ -56,7 +56,7 @@ And the following :math:`3 \times 3` direction cosine matrix (``GlbDCM``) relate
 
 .. _frame:
 
-.. figure:: figs/Frame.jpg
+.. figure:: figs/frame.jpg
    :width: 80%
    :align: center
 


### PR DESCRIPTION
In the input file documentation for beamdyn, the name of the figure in section 6.2.3.2.3 was wrong. It was stated as Frame.jpg. The actual name of the file however is frame.jpg. So changed that to enable visualizing the figure upon building the documentation.