### PR TITLE
Allow to redirect console output to a log file

### DIFF
--- a/modules/nwtc-library/src/SysFlangLinux.f90
+++ b/modules/nwtc-library/src/SysFlangLinux.f90
@@ -55,7 +55,7 @@ MODULE SysSubs
     END INTERFACE
  
     INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-    INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
+    INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
     INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
     LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
     CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -107,7 +107,15 @@ MODULE SysSubs
  
  CONTAINS
  
- 
+ !=======================================================================
+ SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+   
+   INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+   CU = Unit
+   
+ END SUBROUTINE SetConsoleUnit
+ !=======================================================================
  FUNCTION Is_NaN( DblNum )
  
     ! This routine determines if a REAL(DbKi) variable holds a proper number.

--- a/modules/nwtc-library/src/SysGnuLinux.f90
+++ b/modules/nwtc-library/src/SysGnuLinux.f90
@@ -56,7 +56,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -88,6 +88,14 @@ FUNCTION FileSize( Unit )
 
    RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysGnuWin.f90
+++ b/modules/nwtc-library/src/SysGnuWin.f90
@@ -56,7 +56,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -88,6 +88,14 @@ FUNCTION FileSize( Unit )
 
    RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysIFL.f90
+++ b/modules/nwtc-library/src/SysIFL.f90
@@ -56,7 +56,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -90,6 +90,14 @@ FUNCTION FileSize( Unit )
 
    RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysIVF.f90
+++ b/modules/nwtc-library/src/SysIVF.f90
@@ -56,7 +56,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 7                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 7                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]; Note: NewLine change to ACHAR(10) here on Windows to fix issues with C/Fortran interoperability using WrScr
@@ -89,6 +89,14 @@ END IF
 
 RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysIVF_Labview.f90
+++ b/modules/nwtc-library/src/SysIVF_Labview.f90
@@ -73,7 +73,7 @@ MODULE SysSubs
 
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 7                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 7                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
 
    LOGICAL, PARAMETER            :: KBInputOK   = .FALSE.                           ! A flag to tell the program that keyboard input is allowed in the environment.
@@ -125,6 +125,14 @@ CONTAINS
 
    RETURN
    END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+   SUBROUTINE SetConsoleUnit( Unit )
+      ! This subroutine sets the console unit for output.
+
+   INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+   CU = Unit
+
+   END SUBROUTINE SetConsoleUnit
 !=======================================================================
    SUBROUTINE FlushOut ( Unit )
 

--- a/modules/nwtc-library/src/SysMatlabLinuxGnu.f90
+++ b/modules/nwtc-library/src/SysMatlabLinuxGnu.f90
@@ -59,7 +59,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .FALSE.                           ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -91,6 +91,14 @@ FUNCTION FileSize( Unit )
 
    RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysMatlabLinuxIntel.f90
+++ b/modules/nwtc-library/src/SysMatlabLinuxIntel.f90
@@ -59,7 +59,7 @@ MODULE SysSubs
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .FALSE.                           ! A flag to tell the program that keyboard input is allowed in the environment.
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
@@ -93,6 +93,14 @@ FUNCTION FileSize( Unit )
 
    RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
 FUNCTION Is_NaN( DblNum )
 

--- a/modules/nwtc-library/src/SysMatlabWindows.f90
+++ b/modules/nwtc-library/src/SysMatlabWindows.f90
@@ -47,7 +47,7 @@ MODULE SysSubs
 !=======================================================================
 
 
-   INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
+   INTEGER, PRIVATE              :: CU          = 6                                 ! The I/O unit for the console (Can be changed with SetConsoleUnit subroutine)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
 
    LOGICAL, PARAMETER            :: KBInputOK   = .FALSE.                           ! A flag to tell the program that keyboard input is allowed in the environment.
@@ -82,6 +82,14 @@ END IF
 
 RETURN
 END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+SUBROUTINE SetConsoleUnit( Unit )
+   ! This subroutine sets the console unit for output.
+
+INTEGER, INTENT(IN)  :: Unit  !< The new I/O unit number for the console.
+CU = Unit
+
+END SUBROUTINE SetConsoleUnit
 !=======================================================================
    SUBROUTINE FlushOut ( Unit )
 

--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -1037,7 +1037,7 @@ contains
          do i=1,size(InitOut%LinNames_y)
             Flag='F'
             if (InitOut%RotFrame_y(i)) Flag='T'
-            call WrFileNR(CU,'    '//Num2LStr(i)//Flag//'      '//InitOut%LinNames_y(i)//NewLine)
+            call WrScr('    '//Num2LStr(i)//Flag//'      '//InitOut%LinNames_y(i)//NewLine)
          enddo
       endif
       if (allocated(InitOut%LinNames_x)) then
@@ -1059,13 +1059,13 @@ contains
          do i=1,size(InitOut%LinNames_x)
             Flag='F'
             if (InitOut%RotFrame_x(i)) Flag='T'
-            call WrFileNR(CU,'    '//Num2LStr(i)//Flag//'      '//trim(Num2LStr(InitOut%DerivOrder_x(i)))//'     '//InitOut%LinNames_x(i)//NewLine)
+            call WrScr('    '//Num2LStr(i)//Flag//'      '//trim(Num2LStr(InitOut%DerivOrder_x(i)))//'     '//InitOut%LinNames_x(i)//NewLine)
          enddo
       endif
       if (allocated(InitOut%LinNames_u)) then
          call WrScr('Perturb Size u')
          do i=1,size(p%du)
-            call WrFileNR(CU,'          '//trim(Num2LStr(i))//'        '//trim(Num2LStr(p%du(i)))//NewLine)
+            call WrScr('          '//trim(Num2LStr(i))//'        '//trim(Num2LStr(p%du(i)))//NewLine)
          enddo
          call WrScr('LinNames_u')
          do j=1,p%NumBStC
@@ -1087,7 +1087,7 @@ contains
             FlagLoad='F'
             if (InitOut%RotFrame_u(i)) Flag='T'
             if (InitOut%IsLoad_u(i)) FlagLoad='T'
-            call WrFileNR(CU,'    '//Num2LStr(i)//Flag//'      '//FlagLoad//'      ('//   &
+            call WrScr('    '//Num2LStr(i)//Flag//'      '//FlagLoad//'      ('//   &
                               trim(Num2LStr(p%Jac_u_indx(i,1)))//','//trim(Num2LStr(p%Jac_u_indx(i,2)))//','//trim(Num2LStr(p%Jac_u_indx(i,3)))//  &
                            ')     '//InitOut%LinNames_u(i)//NewLine)
          enddo


### PR DESCRIPTION
Support redirecting console output to a log file. This allows for integrating with tools like LabVIEW and still retaining the console output that would otherwise be lost since LabVIEW does not print to the screen.

@deslaughter heads up that I've updated this PR from the original context to only include your new commit. The rest of the changes were included in #30.